### PR TITLE
Add Labs search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DataForSEO MCP Server
 
-Model Context Protocol (MCP) server implementation for DataForSEO, enabling Claude to interact with selected DataForSEO APIs and obtain SEO data through a standardized interface. 
+Model Context Protocol (MCP) server implementation for DataForSEO, enabling ChatGPT or other agents to interact with selected DataForSEO APIs and obtain SEO data through a standardized interface. The server now includes optional tools that satisfy OpenAI's remote MCP requirements for search and document retrieval.
 
 ## Features
 
@@ -35,7 +35,7 @@ export DATAFORSEO_PASSWORD=your_password
 
 # Optional: specify which modules to enable (comma-separated)
 # If not set, all modules will be enabled
-export ENABLED_MODULES="SERP,KEYWORDS_DATA,ONPAGE,DATAFORSEO_LABS,BACKLINKS,BUSINESS_DATA,DOMAIN_ANALYTICS"
+export ENABLED_MODULES="SERP,KEYWORDS_DATA,ONPAGE,DATAFORSEO_LABS,BACKLINKS,BUSINESS_DATA,DOMAIN_ANALYTICS,OPENAI"
 
 # Optional: enable full API responses
 # If not set or set to false, the server will filter and transform API responses to a more concise format
@@ -120,6 +120,7 @@ The following modules are available to be enabled/disabled:
 - `BACKLINKS`: data on inbound links, referring domains and referring pages for any domain, subdomain, or webpage;
 - `BUSINESS_DATA`: based on business reviews and business information publicly shared on the following platforms: Google, Trustpilot, Tripadvisor;
 - `DOMAIN_ANALYTICS`: helps identify all possible technologies used for building websites and offers Whois data;
+- `OPENAI`: provides `search` and `fetch` tools compatible with ChatGPT connectors;
 
 ## Adding New Tools/Modules
 
@@ -249,7 +250,8 @@ export const AVAILABLE_MODULES = [
   'KEYWORDS_DATA',
   'ONPAGE',
   'DATAFORSEO_LABS',
-  'YOUR_MODULE_NAME'  // Add your module name here
+  'YOUR_MODULE_NAME',
+  'OPENAI'  // Built-in module providing search and fetch for ChatGPT
 ] as const;
 ```
 
@@ -271,6 +273,21 @@ We're always looking to expand the capabilities of this MCP server. If you have 
    - Describe any specific features you'd like to see implemented.
 
 Your feedback helps us prioritize which APIs to support next!
+
+## Using with ChatGPT
+
+The `OPENAI` module provides a `search` tool and a `fetch` tool that follow OpenAI's [remote MCP server requirements](https://modelcontextprotocol.io/introduction). Enable the module by including `OPENAI` in the `ENABLED_MODULES` environment variable or leave the variable unset to enable all modules.
+
+The search tool accepts a `query` string and allows optional parameters to refine the request:
+
+- `source` – `serp` for live search engine results (default) or `labs` to use DataForSEO Labs keyword ideas
+- `search_engine` – one of `google`, `bing`, or `yahoo` (used when `source=serp`)
+- `language_code` – language code such as `en`
+- `location_name` – full location name (default `United States`)
+- `depth` – number of results to fetch from SERP (when `source=serp`)
+- `limit` – number of keyword ideas to return (when `source=labs`)
+
+It returns a list of results with `id`, `title`, `text`, and `url`. Use the `fetch` tool with a returned `id` to retrieve the full record for citation in ChatGPT.
 
 ## Resources
 

--- a/src/config/modules.config.ts
+++ b/src/config/modules.config.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 // Define available module names
-export const AVAILABLE_MODULES = ['SERP', 'KEYWORDS_DATA', 'ONPAGE', 'DATAFORSEO_LABS', 'BACKLINKS', 'BUSINESS_DATA', 'DOMAIN_ANALYTICS'] as const;
+export const AVAILABLE_MODULES = ['SERP', 'KEYWORDS_DATA', 'ONPAGE', 'DATAFORSEO_LABS', 'BACKLINKS', 'BUSINESS_DATA', 'DOMAIN_ANALYTICS', 'OPENAI'] as const;
 export type ModuleName = typeof AVAILABLE_MODULES[number];
 
 // Schema for validating the ENABLED_MODULES environment variable

--- a/src/index-http.ts
+++ b/src/index-http.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { BacklinksApiModule } from "./modules/backlinks/backlinks-api.module.js";
 import { BusinessDataApiModule } from "./modules/business-data-api/business-data-api.module.js";
 import { DomainAnalyticsApiModule } from "./modules/domain-analytics/domain-analytics-api.module.js";
+import { OpenAIToolsModule } from "./modules/openai/openai.module.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import express, { Request as ExpressRequest, Response, NextFunction } from "express";
 import { randomUUID } from "node:crypto";
@@ -87,6 +88,9 @@ function getServer(username: string | undefined, password: string | undefined) :
   }
   if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
     modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
+  }
+  if (isModuleEnabled('OPENAI', enabledModules)) {
+    modules.push(new OpenAIToolsModule(dataForSEOClient));
   }
   console.error('Modules initialized');
   function registerModuleTools() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,10 @@ import { DataForSEOLabsApi } from './modules/dataforseo-labs/dataforseo-labs-api
 import { EnabledModulesSchema, isModuleEnabled, defaultEnabledModules } from './config/modules.config.js';
 import { BaseModule } from './modules/base.module.js';
 import { z } from 'zod';
-import { BacklinksApiModule } from "./modules/backlinks/backlinks-api.module.js";7
+import { BacklinksApiModule } from "./modules/backlinks/backlinks-api.module.js";
 import { BusinessDataApiModule } from "./modules/business-data-api/business-data-api.module.js";
 import { DomainAnalyticsApiModule } from "./modules/domain-analytics/domain-analytics-api.module.js";
+import { OpenAIToolsModule } from "./modules/openai/openai.module.js";
 
 interface ToolDefinition {
   description: string;
@@ -62,6 +63,9 @@ if (isModuleEnabled('BUSINESS_DATA', enabledModules)) {
 }
 if (isModuleEnabled('DOMAIN_ANALYTICS', enabledModules)) {
   modules.push(new DomainAnalyticsApiModule(dataForSEOClient));
+}
+if (isModuleEnabled('OPENAI', enabledModules)) {
+  modules.push(new OpenAIToolsModule(dataForSEOClient));
 }
 console.error('Modules initialized');
 

--- a/src/modules/openai/openai.module.ts
+++ b/src/modules/openai/openai.module.ts
@@ -1,0 +1,26 @@
+import { BaseModule, ToolDefinition } from '../base.module.js';
+import { DataForSEOClient } from '../../client/dataforseo.client.js';
+import { SearchTool } from './tools/search.tool.js';
+import { FetchTool } from './tools/fetch.tool.js';
+
+export class OpenAIToolsModule extends BaseModule {
+  constructor(private client: DataForSEOClient) {
+    super(client);
+  }
+
+  getTools(): Record<string, ToolDefinition> {
+    const tools = [
+      new SearchTool(this.client),
+      new FetchTool(this.client),
+    ];
+
+    return tools.reduce((acc, tool) => ({
+      ...acc,
+      [tool.getName()]: {
+        description: tool.getDescription(),
+        params: tool.getParams(),
+        handler: (params: any) => tool.handle(params),
+      },
+    }), {});
+  }
+}

--- a/src/modules/openai/tools/fetch.tool.ts
+++ b/src/modules/openai/tools/fetch.tool.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { BaseTool } from '../../base.tool.js';
+import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+import { getStore } from './search.tool.js';
+
+export class FetchTool extends BaseTool {
+  constructor(private client: DataForSEOClient) {
+    super(client);
+  }
+
+  getName(): string { return 'fetch'; }
+
+  getDescription(): string {
+    return 'Retrieve detailed SERP information for a result returned by the search tool.';
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      id: z.string().describe('ID of the resource to fetch.')
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    const item = getStore().get(params.id);
+    if (!item) {
+      return this.formatErrorResponse(new Error('unknown id'));
+    }
+    return {
+      id: params.id,
+      title: item.title,
+      text: item.description || item.snippet || '',
+      url: item.url,
+      metadata: item
+    };
+  }
+}

--- a/src/modules/openai/tools/search.tool.ts
+++ b/src/modules/openai/tools/search.tool.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { BaseTool } from '../../base.tool.js';
+import { DataForSEOClient } from '../../../client/dataforseo.client.js';
+import { randomUUID } from 'node:crypto';
+
+const store = new Map<string, any>();
+export function getStore() { return store; }
+
+export class SearchTool extends BaseTool {
+  constructor(private client: DataForSEOClient) {
+    super(client);
+  }
+
+  getName(): string { return 'search'; }
+
+  getDescription(): string {
+    return 'Search DataForSEO. Use `source=serp` for live search engine results or `source=labs` for keyword ideas from DataForSEO Labs.';
+  }
+
+  getParams(): z.ZodRawShape {
+    return {
+      query: z.string().describe('Search keyword'),
+      source: z.enum(['serp', 'labs']).default('serp').describe('Data source: serp for live search engine results or labs for DataForSEO Labs keyword ideas'),
+      search_engine: z.enum(['google', 'bing', 'yahoo']).default('google').describe('Search engine name (for source=serp)'),
+      language_code: z.string().default('en').describe("Language code (e.g., 'en')"),
+      location_name: z.string().default('United States').describe('Full location name'),
+      depth: z.number().min(10).max(700).default(10).describe('Number of results to fetch from SERP (source=serp)'),
+      limit: z.number().min(1).max(1000).default(10).describe('Number of keyword ideas to return (source=labs)')
+    };
+  }
+
+  async handle(params: any): Promise<any> {
+    try {
+      let items: any[] = [];
+      if (params.source === 'labs') {
+        const response: any = await this.client.makeRequest('/v3/dataforseo_labs/google/keyword_ideas/live', 'POST', [{
+          keywords: [params.query],
+          location_name: params.location_name,
+          language_code: params.language_code,
+          limit: params.limit,
+        }], true);
+        items = response?.tasks?.[0]?.result?.[0]?.items || [];
+        const results = items.map((item: any) => {
+          const id = randomUUID();
+          store.set(id, item);
+          return {
+            id,
+            title: item.keyword || item.keyword_data?.keyword,
+            text: `search volume: ${item.keyword_info?.search_volume ?? ''}`,
+            url: null
+          };
+        });
+        return { results };
+      } else {
+        const response: any = await this.client.makeRequest(`/v3/serp/${params.search_engine}/organic/live/advanced`, 'POST', [{
+          keyword: params.query,
+          location_name: params.location_name,
+          language_code: params.language_code,
+          depth: params.depth,
+        }], true);
+        items = response?.tasks?.[0]?.result?.[0]?.items || [];
+        const results = items.map((item: any) => {
+          const id = randomUUID();
+          store.set(id, item);
+          return {
+            id,
+            title: item.title,
+            text: item.description || item.snippet || '',
+            url: item.url
+          };
+        });
+        return { results };
+      }
+    } catch (error) {
+      return this.formatErrorResponse(error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow search tool to use DataForSEO Labs keyword ideas via `source=labs`
- document new `source` and `limit` parameters for ChatGPT usage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68596d8144808332aca3c4885a477e49